### PR TITLE
Use `application/json` header for POST requests

### DIFF
--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -34,7 +34,7 @@ function sendHttpRequest(ToUrl,withJson,folderIndex,rowIndex,method) {
     // Have to to XMLHttpRequest because we dont have jquery :(
     // Testing was done via jquery ajax so results MAY be different
     // Particularly the request content-type (json vs form)
-    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xhr.setRequestHeader("Content-Type", "application/json");
     var parameterizedUrl = Object.keys(strToJson).map(function(k) {
       return encodeURIComponent(k) + '=' + encodeURIComponent(strToJson[k])
     }).join('&');


### PR DESCRIPTION
Currently, the `PUT`-request is using the content-type-header `application/json` but the POST-request `application/x-www-form-urlencoded`.
But both are sending a json payload. And some backends want that this header is set.
